### PR TITLE
Allow vendoring CRDs of arbitrary Git tag

### DIFF
--- a/cue-schemas/main.go
+++ b/cue-schemas/main.go
@@ -149,7 +149,7 @@ func (m *CueSchemas) VendorGithub(
 		ctr = ctr.WithWorkdir(mod).
 			WithExec([]string{"cue", "mod", "init", fmt.Sprintf("%s@v%d", mod, semver.Major()), "--source=self"}).
 			WithWorkdir("..")
-		ctr = ctr.WithDirectory(fmt.Sprintf("%s-%s", mod, gitTag), ctr.Directory(mod)).
+		ctr = ctr.WithDirectory(fmt.Sprintf("%s-%s", mod, tag), ctr.Directory(mod)).
 			WithoutDirectory(mod)
 	}
 	return ctr.Directory("."), nil

--- a/cue-schemas/schema.cue
+++ b/cue-schemas/schema.cue
@@ -4,6 +4,7 @@ package schema
 
 #GithubSource: {
 	tag:       #Semver
+	gitTag:    string | *tag
 	githubURL: *"https://github.com" | string
 	owner:     =~#"^[\w\.-]+$"#
 	repo:      =~#"^[\w\.-]+$"#


### PR DESCRIPTION
No longer does the GitTag have to follow SemVer.